### PR TITLE
Added missing dependencies pyhtml2text and jq.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN set -xe \
                                 chump             \
                                 cssbeautifier     \
                                 cssselect         \
+                                html2text         \
+                                jq                \
                                 jsbeautifier      \
                                 keyring           \
                                 keyrings.alt      \


### PR DESCRIPTION
Some of the python dependencies have been missing, this should fix the `pyhtml2text` and `jq` filters.